### PR TITLE
Fixed breaking when the class is originally a single string instead of array

### DIFF
--- a/stanford_image_styles.module
+++ b/stanford_image_styles.module
@@ -14,5 +14,8 @@ include_once 'stanford_image_styles.features.inc';
  *   The image theme vars.
  */
 function stanford_image_styles_preprocess_image_style(array &$vars) {
+  if (isset($vars['attributes']['class']) && is_string($vars['attributes']['class'])) {
+    $vars['attributes']['class'] = array($vars['attributes']['class']);
+  }
   $vars['attributes']['class'][] = "image-style-" . drupal_clean_css_identifier($vars['style_name']);
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- When viewing certain pages, the class is actually a string instead of an array. This changes it to array then adds the class.

# Needed By (Date)
- Soon

# Urgency
- High Urgency

# Steps to Test

1. checkout 7.x-4.x and view admin/stanford-jumpstart/customize-design page
2. error should occur.
3. checkout this branch, and refresh the page.
4. no error should occur.