### PR TITLE
SOE-2510: New image style for facebook sharing

### DIFF
--- a/stanford_image_styles.features.inc
+++ b/stanford_image_styles.features.inc
@@ -972,5 +972,20 @@ function stanford_image_styles_image_default_styles() {
     ),
   );
 
+  // Exported image style: facebook_share_image.
+  $styles['facebook_share_image'] = array(
+    'label' => 'Facebook Share Image',
+    'effects' => array(
+      1 => array(
+        'name' => 'image_scale_and_crop',
+        'data' => array(
+          'width' => 1200,
+          'height' => 630,
+        ),
+        'weight' => 1,
+      ),
+    ),
+  );
+
   return $styles;
 }

--- a/stanford_image_styles.info
+++ b/stanford_image_styles.info
@@ -56,4 +56,5 @@ features[image][] = square_scale_and_crop_270_x_270
 features[image][] = thmb-landscape
 features[image][] = thmb-profile
 features[image][] = thmb-square
+features[image][] = facebook_share_image
 project status url = https://github.com/SU-SWS/stanford_image_styles


### PR DESCRIPTION
# Summary
- Facebook was not able to reliably find and cache magazine article images for sharing on their platform.  It appears that either the images were too large or Facebook preferred they be the 1200x630 recommended size for pre-caching.

# Needed By (12/18)

# Urgency
- SOE has an email newsletter they would like to send Tues. 12/19 around 9am.  They would like this on their live site before then.

# Steps to Test
1. See: https://github.com/SU-SOE/stanford_soe_helper/pull/137

# Affected Projects or Products
- SOE's upcoming email newsletter
- This work will go into a 7.x-4.3-alpha1 release of this module

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-2510
- PR: https://github.com/SU-SOE/stanford_soe_helper/pull/137
- @boznik @sherakama @cjwest 