### PR TITLE
D8CORE-2055: image style for the person node

### DIFF
--- a/config/install/image.style.medium_circle.yml
+++ b/config/install/image.style.medium_circle.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+    - image_effects
+name: medium_circle
+label: 'Medium Circle (220x220)'
+effects:
+  c13a7d38-0ff7-48b9-94b0-1f5be2684729:
+    uuid: c13a7d38-0ff7-48b9-94b0-1f5be2684729
+    id: focal_point_scale_and_crop
+    weight: -10
+    data:
+      width: 220
+      height: 220
+      crop_type: focal_point
+  e16766ec-37b4-4d36-8fce-615ed14ea929:
+    uuid: e16766ec-37b4-4d36-8fce-615ed14ea929
+    id: image_convert
+    weight: -9
+    data:
+      extension: png
+  d928d89a-3854-42a1-bed7-25a7201ac606:
+    uuid: d928d89a-3854-42a1-bed7-25a7201ac606
+    id: image_effects_mask
+    weight: -8
+    data:
+      mask_image: modules/custom/stanford_person/dist/assets/img/mask-image_220px.png
+      mask_width: ''
+      mask_height: ''
+      placement: center-center
+      x_offset: ''
+      y_offset: ''


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changing the Image Style for the Person note

# Review By (Date)
- ASAP

# Criticality
- Critical for Person

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
1b. Checkout this branch on Stanford_person.
2. Navigate to a person node page.
3. Verify the profile image is 220px for XL, LG, SM & XS. MD should be 200px.

## Front End Validation
- [ ] Is the markup using the appropriate semantic tags and passes HTML validation?
- [x] Cross-browser testing has been performed?
- [x] Automated accessibility scans performed? - Axe & Wave
- [ ] Manual accessibility tests performed?
- [x] Design is requested by our design team

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Person Accelerant

# Associated Issues and/or People
- D8CORE-2055
- Stanford_image_styles new image config. 
