### PR TITLE
D8CORE-2155: Added square image styles for various breakpoints

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+# READY FOR REVIEW/NOT READY
+- (Edit the above to reflect status)
+
+# Summary
+- TL;DR - what's this PR for?
+
+# Needed By (Date)
+- When does this need to be merged by?
+
+# Urgency
+- How critical is this PR?
+
+# Steps to Test
+
+1. Do this
+1. Then this
+2. Then this
+
+# Affected Projects or Products
+- Does this PR impact any particular projects, products, or modules?
+
+# Associated Issues and/or People
+- JIRA ticket
+- Other PRs
+- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
+- Anyone who should be notified? (`@mention` them here)
+
+# See Also
+- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)

--- a/config/install/image.style.breakpoint_2xl_1x.yml
+++ b/config/install/image.style.breakpoint_2xl_1x.yml
@@ -5,10 +5,10 @@ name: breakpoint_2xl_1x
 label: 'Breakpoint - 2XL - 1x'
 effects:
   1d3ee4ae-e4f1-4c5f-8d8b-c366720d6b83:
-    uuid: 1d3ee4ae-e4f1-4c5f-8d8b-c366720d6b83
     id: image_scale
     weight: 1
     data:
       width: 1500
       height: null
       upscale: false
+

--- a/config/install/image.style.breakpoint_2xl_1x.yml
+++ b/config/install/image.style.breakpoint_2xl_1x.yml
@@ -5,6 +5,7 @@ name: breakpoint_2xl_1x
 label: 'Breakpoint - 2XL - 1x'
 effects:
   1d3ee4ae-e4f1-4c5f-8d8b-c366720d6b83:
+    uuid: 1d3ee4ae-e4f1-4c5f-8d8b-c366720d6b83
     id: image_scale
     weight: 1
     data:

--- a/config/install/image.style.breakpoint_2xl_2x.yml
+++ b/config/install/image.style.breakpoint_2xl_2x.yml
@@ -5,10 +5,10 @@ name: breakpoint_2xl_2x
 label: 'Breakpoint - 2XL - 2x'
 effects:
   ad3f3a45-2c07-4b34-a146-e5253cadc5a1:
-    uuid: ad3f3a45-2c07-4b34-a146-e5253cadc5a1
     id: image_scale
     weight: 1
     data:
       width: 3000
       height: null
       upscale: false
+

--- a/config/install/image.style.breakpoint_2xl_2x.yml
+++ b/config/install/image.style.breakpoint_2xl_2x.yml
@@ -5,6 +5,7 @@ name: breakpoint_2xl_2x
 label: 'Breakpoint - 2XL - 2x'
 effects:
   ad3f3a45-2c07-4b34-a146-e5253cadc5a1:
+    uuid: ad3f3a45-2c07-4b34-a146-e5253cadc5a1
     id: image_scale
     weight: 1
     data:

--- a/config/install/image.style.breakpoint_lg_1x.yml
+++ b/config/install/image.style.breakpoint_lg_1x.yml
@@ -1,16 +1,14 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: 3aTh0wxysVWRLQvsLSWuf9mYdAql9Ek2O4okVXG5cMs
 name: breakpoint_lg_1x
 label: 'Breakpoint - LG - 1x'
 effects:
   93ae1a84-50be-4100-a278-1b4dd7199ea7:
-    uuid: 93ae1a84-50be-4100-a278-1b4dd7199ea7
     id: image_scale
     weight: 1
     data:
       width: 992
       height: null
       upscale: false
+

--- a/config/install/image.style.breakpoint_lg_1x.yml
+++ b/config/install/image.style.breakpoint_lg_1x.yml
@@ -5,6 +5,7 @@ name: breakpoint_lg_1x
 label: 'Breakpoint - LG - 1x'
 effects:
   93ae1a84-50be-4100-a278-1b4dd7199ea7:
+    uuid: 93ae1a84-50be-4100-a278-1b4dd7199ea7
     id: image_scale
     weight: 1
     data:

--- a/config/install/image.style.breakpoint_lg_2x.yml
+++ b/config/install/image.style.breakpoint_lg_2x.yml
@@ -5,6 +5,7 @@ name: breakpoint_lg_2x
 label: 'Breakpoint - LG - 2x'
 effects:
   ec07d008-ae5e-487b-b92b-315fdc56598b:
+    uuid: ec07d008-ae5e-487b-b92b-315fdc56598b
     id: image_scale
     weight: 1
     data:

--- a/config/install/image.style.breakpoint_lg_2x.yml
+++ b/config/install/image.style.breakpoint_lg_2x.yml
@@ -1,16 +1,14 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: cZXot4swbaAIIWXQw7ZhgPwlabmSTQOCZO8AIM5isGE
 name: breakpoint_lg_2x
 label: 'Breakpoint - LG - 2x'
 effects:
   ec07d008-ae5e-487b-b92b-315fdc56598b:
-    uuid: ec07d008-ae5e-487b-b92b-315fdc56598b
     id: image_scale
     weight: 1
     data:
       width: 1984
       height: null
       upscale: false
+

--- a/config/install/image.style.breakpoint_md_1x.yml
+++ b/config/install/image.style.breakpoint_md_1x.yml
@@ -5,6 +5,7 @@ name: breakpoint_md_1x
 label: 'Breakpoint - MD - 1x'
 effects:
   71c771d2-63fd-4052-aa17-37d0028d2ffe:
+    uuid: 71c771d2-63fd-4052-aa17-37d0028d2ffe
     id: image_scale
     weight: 1
     data:

--- a/config/install/image.style.breakpoint_md_1x.yml
+++ b/config/install/image.style.breakpoint_md_1x.yml
@@ -1,16 +1,14 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: ofY6kXeN4lN9PG-eTaA78tAzx3ACWtTmlK-APH7PAZg
 name: breakpoint_md_1x
 label: 'Breakpoint - MD - 1x'
 effects:
   71c771d2-63fd-4052-aa17-37d0028d2ffe:
-    uuid: 71c771d2-63fd-4052-aa17-37d0028d2ffe
     id: image_scale
     weight: 1
     data:
       width: 768
       height: null
       upscale: false
+

--- a/config/install/image.style.breakpoint_md_2x.yml
+++ b/config/install/image.style.breakpoint_md_2x.yml
@@ -1,16 +1,14 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: TJO8X5EvB-f6_JLymfBhl0dJ2bP0rbm94sJLiSDGkGk
 name: breakpoint_md_2x
 label: 'Breakpoint - MD - 2x'
 effects:
   249a87bb-f700-4ded-9288-8352ec253e0a:
-    uuid: 249a87bb-f700-4ded-9288-8352ec253e0a
     id: image_scale
     weight: 1
     data:
       width: 1536
       height: null
       upscale: false
+

--- a/config/install/image.style.breakpoint_md_2x.yml
+++ b/config/install/image.style.breakpoint_md_2x.yml
@@ -5,6 +5,7 @@ name: breakpoint_md_2x
 label: 'Breakpoint - MD - 2x'
 effects:
   249a87bb-f700-4ded-9288-8352ec253e0a:
+    uuid: 249a87bb-f700-4ded-9288-8352ec253e0a
     id: image_scale
     weight: 1
     data:

--- a/config/install/image.style.breakpoint_sm_1x.yml
+++ b/config/install/image.style.breakpoint_sm_1x.yml
@@ -1,16 +1,14 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: G0Vkgl6yKu6iHRjh_xyTEUsbM_lAgQ362aTGF_edkg0
 name: breakpoint_sm_1x
 label: 'Breakpoint - SM - 1x'
 effects:
   8fd0f5de-1f16-419b-af3a-4052445887fe:
-    uuid: 8fd0f5de-1f16-419b-af3a-4052445887fe
     id: image_scale
     weight: 1
     data:
       width: 576
       height: null
       upscale: false
+

--- a/config/install/image.style.breakpoint_sm_1x.yml
+++ b/config/install/image.style.breakpoint_sm_1x.yml
@@ -5,6 +5,7 @@ name: breakpoint_sm_1x
 label: 'Breakpoint - SM - 1x'
 effects:
   8fd0f5de-1f16-419b-af3a-4052445887fe:
+    uuid: 8fd0f5de-1f16-419b-af3a-4052445887fe
     id: image_scale
     weight: 1
     data:

--- a/config/install/image.style.breakpoint_sm_2x.yml
+++ b/config/install/image.style.breakpoint_sm_2x.yml
@@ -1,16 +1,14 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: jR527GaKk-Mxem_ZnKUgnnXSaqpURbAxzC9WajqFb40
 name: breakpoint_sm_2x
 label: 'Breakpoint - SM - 2x'
 effects:
   64625c59-2ad8-4070-94fb-5df62ef2b5d9:
-    uuid: 64625c59-2ad8-4070-94fb-5df62ef2b5d9
     id: image_scale
     weight: 1
     data:
       width: 1152
       height: null
       upscale: false
+

--- a/config/install/image.style.breakpoint_sm_2x.yml
+++ b/config/install/image.style.breakpoint_sm_2x.yml
@@ -5,6 +5,7 @@ name: breakpoint_sm_2x
 label: 'Breakpoint - SM - 2x'
 effects:
   64625c59-2ad8-4070-94fb-5df62ef2b5d9:
+    uuid: 64625c59-2ad8-4070-94fb-5df62ef2b5d9
     id: image_scale
     weight: 1
     data:

--- a/config/install/image.style.breakpoint_xl_1x.yml
+++ b/config/install/image.style.breakpoint_xl_1x.yml
@@ -1,16 +1,14 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: Uy8HsoXATXaSNELbQv6oHjVXQ7CngyBOwJHzGkmOonY
 name: breakpoint_xl_1x
 label: 'Breakpoint - XL - 1x'
 effects:
   49353971-6d42-4a99-a3be-83548d359973:
-    uuid: 49353971-6d42-4a99-a3be-83548d359973
     id: image_scale
     weight: 1
     data:
       width: 1200
       height: null
       upscale: false
+

--- a/config/install/image.style.breakpoint_xl_1x.yml
+++ b/config/install/image.style.breakpoint_xl_1x.yml
@@ -5,6 +5,7 @@ name: breakpoint_xl_1x
 label: 'Breakpoint - XL - 1x'
 effects:
   49353971-6d42-4a99-a3be-83548d359973:
+    uuid: 49353971-6d42-4a99-a3be-83548d359973
     id: image_scale
     weight: 1
     data:

--- a/config/install/image.style.breakpoint_xl_2x.yml
+++ b/config/install/image.style.breakpoint_xl_2x.yml
@@ -5,6 +5,7 @@ name: breakpoint_xl_2x
 label: 'Breakpoint - XL - 2x'
 effects:
   91b0ad18-b477-4d00-8e5d-db3fa2fba70b:
+    uuid: 91b0ad18-b477-4d00-8e5d-db3fa2fba70b
     id: image_scale
     weight: 1
     data:

--- a/config/install/image.style.breakpoint_xl_2x.yml
+++ b/config/install/image.style.breakpoint_xl_2x.yml
@@ -1,16 +1,14 @@
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: Vh36ZWh1RSikZ0pbEJjgQa4UPqirYo__IZ1NsmQwTPA
 name: breakpoint_xl_2x
 label: 'Breakpoint - XL - 2x'
 effects:
   91b0ad18-b477-4d00-8e5d-db3fa2fba70b:
-    uuid: 91b0ad18-b477-4d00-8e5d-db3fa2fba70b
     id: image_scale
     weight: 1
     data:
       width: 2400
       height: null
       upscale: false
+

--- a/config/install/image.style.card_1x_478x318.yml
+++ b/config/install/image.style.card_1x_478x318.yml
@@ -7,10 +7,10 @@ name: card_1x_478x318
 label: 'Card - 1X - 478x318'
 effects:
   4d7dd7d6-b4c9-475a-8ee0-8202c4c9ed27:
-    uuid: 4d7dd7d6-b4c9-475a-8ee0-8202c4c9ed27
     id: focal_point_scale_and_crop
     weight: 1
     data:
       width: 478
       height: 318
       crop_type: focal_point
+

--- a/config/install/image.style.card_1x_478x318.yml
+++ b/config/install/image.style.card_1x_478x318.yml
@@ -7,6 +7,7 @@ name: card_1x_478x318
 label: 'Card - 1X - 478x318'
 effects:
   4d7dd7d6-b4c9-475a-8ee0-8202c4c9ed27:
+    uuid: 4d7dd7d6-b4c9-475a-8ee0-8202c4c9ed27
     id: focal_point_scale_and_crop
     weight: 1
     data:

--- a/config/install/image.style.card_2x_956x636.yml
+++ b/config/install/image.style.card_2x_956x636.yml
@@ -7,6 +7,7 @@ name: card_2x_956x636
 label: 'Card - 2X - 956x636'
 effects:
   2d61f395-da00-4db7-a98d-c9a4e3e1ba6d:
+    uuid: 2d61f395-da00-4db7-a98d-c9a4e3e1ba6d
     id: focal_point_scale_and_crop
     weight: 1
     data:

--- a/config/install/image.style.cta_1x_507x338.yml
+++ b/config/install/image.style.cta_1x_507x338.yml
@@ -7,10 +7,10 @@ name: cta_1x_507x338
 label: 'CTA - 1X - 507x338'
 effects:
   21c139d3-cf45-4994-a2c0-69d456bf238d:
-    uuid: 21c139d3-cf45-4994-a2c0-69d456bf238d
     id: focal_point_scale_and_crop
     weight: 1
     data:
       width: 507
       height: 338
       crop_type: focal_point
+

--- a/config/install/image.style.cta_1x_507x338.yml
+++ b/config/install/image.style.cta_1x_507x338.yml
@@ -7,6 +7,7 @@ name: cta_1x_507x338
 label: 'CTA - 1X - 507x338'
 effects:
   21c139d3-cf45-4994-a2c0-69d456bf238d:
+    uuid: 21c139d3-cf45-4994-a2c0-69d456bf238d
     id: focal_point_scale_and_crop
     weight: 1
     data:

--- a/config/install/image.style.cta_1x_596x397.yml
+++ b/config/install/image.style.cta_1x_596x397.yml
@@ -7,10 +7,10 @@ name: cta_1x_596x397
 label: 'CTA - 1X - 596x397'
 effects:
   19ac28d7-7fb1-4568-a745-c346a086d411:
-    uuid: 19ac28d7-7fb1-4568-a745-c346a086d411
     id: focal_point_scale_and_crop
     weight: 1
     data:
       width: 596
       height: 397
       crop_type: focal_point
+

--- a/config/install/image.style.cta_1x_596x397.yml
+++ b/config/install/image.style.cta_1x_596x397.yml
@@ -7,6 +7,7 @@ name: cta_1x_596x397
 label: 'CTA - 1X - 596x397'
 effects:
   19ac28d7-7fb1-4568-a745-c346a086d411:
+    uuid: 19ac28d7-7fb1-4568-a745-c346a086d411
     id: focal_point_scale_and_crop
     weight: 1
     data:

--- a/config/install/image.style.cta_2x_1014x676.yml
+++ b/config/install/image.style.cta_2x_1014x676.yml
@@ -7,6 +7,7 @@ name: cta_2x_1014x676
 label: 'CTA - 2X - 1014x676'
 effects:
   135c1d89-e8f1-4da2-8298-603f3dac413a:
+    uuid: 135c1d89-e8f1-4da2-8298-603f3dac413a
     id: focal_point_scale_and_crop
     weight: 1
     data:

--- a/config/install/image.style.cta_2x_1014x676.yml
+++ b/config/install/image.style.cta_2x_1014x676.yml
@@ -7,10 +7,10 @@ name: cta_2x_1014x676
 label: 'CTA - 2X - 1014x676'
 effects:
   135c1d89-e8f1-4da2-8298-603f3dac413a:
-    uuid: 135c1d89-e8f1-4da2-8298-603f3dac413a
     id: focal_point_scale_and_crop
     weight: 1
     data:
       width: 1014
       height: 676
       crop_type: focal_point
+

--- a/config/install/image.style.cta_2x_1192x794.yml
+++ b/config/install/image.style.cta_2x_1192x794.yml
@@ -7,6 +7,7 @@ name: cta_2x_1192x794
 label: 'CTA - 2X - 1192x794'
 effects:
   53821e7f-a825-4519-86f8-84dff276b0c6:
+    uuid: 53821e7f-a825-4519-86f8-84dff276b0c6
     id: focal_point_scale_and_crop
     weight: 1
     data:

--- a/config/install/image.style.cta_2x_1192x794.yml
+++ b/config/install/image.style.cta_2x_1192x794.yml
@@ -7,10 +7,10 @@ name: cta_2x_1192x794
 label: 'CTA - 2X - 1192x794'
 effects:
   53821e7f-a825-4519-86f8-84dff276b0c6:
-    uuid: 53821e7f-a825-4519-86f8-84dff276b0c6
     id: focal_point_scale_and_crop
     weight: 1
     data:
       width: 1192
       height: 794
       crop_type: focal_point
+

--- a/config/install/image.style.square_1192.yml
+++ b/config/install/image.style.square_1192.yml
@@ -7,6 +7,7 @@ name: square_1192
 label: 'Square - 1192'
 effects:
   e1b9c81d-c281-4e9d-b145-28144e978ac0:
+    uuid: e1b9c81d-c281-4e9d-b145-28144e978ac0
     id: focal_point_scale_and_crop
     weight: 1
     data:

--- a/config/install/image.style.square_1192.yml
+++ b/config/install/image.style.square_1192.yml
@@ -3,14 +3,14 @@ status: true
 dependencies:
   module:
     - focal_point
-name: card_2x_956x636
-label: 'Card - 2X - 956x636'
+name: square_1192
+label: 'Square - 1192'
 effects:
-  2d61f395-da00-4db7-a98d-c9a4e3e1ba6d:
+  e1b9c81d-c281-4e9d-b145-28144e978ac0:
     id: focal_point_scale_and_crop
     weight: 1
     data:
-      width: 956
-      height: 366
+      width: 1192
+      height: 1192
       crop_type: focal_point
 

--- a/config/install/image.style.square_1900.yml
+++ b/config/install/image.style.square_1900.yml
@@ -3,14 +3,14 @@ status: true
 dependencies:
   module:
     - focal_point
-name: card_2x_956x636
-label: 'Card - 2X - 956x636'
+name: square_1900
+label: 'Square - 1900'
 effects:
-  2d61f395-da00-4db7-a98d-c9a4e3e1ba6d:
+  578f3e25-6a90-4db7-a90c-91ce8bf4d99e:
     id: focal_point_scale_and_crop
     weight: 1
     data:
-      width: 956
-      height: 366
+      width: 1900
+      height: 1900
       crop_type: focal_point
 

--- a/config/install/image.style.square_1900.yml
+++ b/config/install/image.style.square_1900.yml
@@ -7,6 +7,7 @@ name: square_1900
 label: 'Square - 1900'
 effects:
   578f3e25-6a90-4db7-a90c-91ce8bf4d99e:
+    uuid: 578f3e25-6a90-4db7-a90c-91ce8bf4d99e
     id: focal_point_scale_and_crop
     weight: 1
     data:

--- a/config/install/image.style.square_478.yml
+++ b/config/install/image.style.square_478.yml
@@ -3,14 +3,14 @@ status: true
 dependencies:
   module:
     - focal_point
-name: card_2x_956x636
-label: 'Card - 2X - 956x636'
+name: square_478
+label: 'Square - 478'
 effects:
-  2d61f395-da00-4db7-a98d-c9a4e3e1ba6d:
+  1891a880-3259-4e36-a1e8-9d9f9de467d0:
     id: focal_point_scale_and_crop
     weight: 1
     data:
-      width: 956
-      height: 366
+      width: 478
+      height: 478
       crop_type: focal_point
 

--- a/config/install/image.style.square_478.yml
+++ b/config/install/image.style.square_478.yml
@@ -7,6 +7,7 @@ name: square_478
 label: 'Square - 478'
 effects:
   1891a880-3259-4e36-a1e8-9d9f9de467d0:
+    uuid: 1891a880-3259-4e36-a1e8-9d9f9de467d0
     id: focal_point_scale_and_crop
     weight: 1
     data:

--- a/config/install/image.style.square_956.yml
+++ b/config/install/image.style.square_956.yml
@@ -7,6 +7,7 @@ name: square_956
 label: 'Square - 956'
 effects:
   d383578e-88ff-41aa-830d-526c90d3df98:
+    uuid: d383578e-88ff-41aa-830d-526c90d3df98
     id: focal_point_scale_and_crop
     weight: 1
     data:

--- a/config/install/image.style.square_956.yml
+++ b/config/install/image.style.square_956.yml
@@ -3,14 +3,14 @@ status: true
 dependencies:
   module:
     - focal_point
-name: card_2x_956x636
-label: 'Card - 2X - 956x636'
+name: square_956
+label: 'Square - 956'
 effects:
-  2d61f395-da00-4db7-a98d-c9a4e3e1ba6d:
+  d383578e-88ff-41aa-830d-526c90d3df98:
     id: focal_point_scale_and_crop
     weight: 1
     data:
       width: 956
-      height: 366
+      height: 956
       crop_type: focal_point
 

--- a/config/install/image.style.stanford_circle.yml
+++ b/config/install/image.style.stanford_circle.yml
@@ -8,7 +8,6 @@ name: stanford_circle
 label: Circle
 effects:
   0b2a1b5b-65aa-4c03-ad55-f0d64e9414d1:
-    uuid: 0b2a1b5b-65aa-4c03-ad55-f0d64e9414d1
     id: focal_point_scale_and_crop
     weight: -10
     data:
@@ -16,7 +15,6 @@ effects:
       height: 140
       crop_type: focal_point
   716304f7-4bc8-4c20-b3da-a8f0e50ee7dd:
-    uuid: 716304f7-4bc8-4c20-b3da-a8f0e50ee7dd
     id: image_effects_mask
     weight: -8
     data:
@@ -27,8 +25,8 @@ effects:
       x_offset: ''
       y_offset: ''
   83015ef1-511a-465f-8385-cb64a345c3c8:
-    uuid: 83015ef1-511a-465f-8385-cb64a345c3c8
     id: image_convert
     weight: -9
     data:
       extension: png
+

--- a/config/install/image.style.stanford_circle.yml
+++ b/config/install/image.style.stanford_circle.yml
@@ -8,6 +8,7 @@ name: stanford_circle
 label: Circle
 effects:
   0b2a1b5b-65aa-4c03-ad55-f0d64e9414d1:
+    uuid: 0b2a1b5b-65aa-4c03-ad55-f0d64e9414d1
     id: focal_point_scale_and_crop
     weight: -10
     data:
@@ -15,6 +16,7 @@ effects:
       height: 140
       crop_type: focal_point
   716304f7-4bc8-4c20-b3da-a8f0e50ee7dd:
+    uuid: 716304f7-4bc8-4c20-b3da-a8f0e50ee7dd
     id: image_effects_mask
     weight: -8
     data:
@@ -25,6 +27,7 @@ effects:
       x_offset: ''
       y_offset: ''
   83015ef1-511a-465f-8385-cb64a345c3c8:
+    uuid: 83015ef1-511a-465f-8385-cb64a345c3c8
     id: image_convert
     weight: -9
     data:

--- a/config/install/responsive_image.styles.card_478x318.yml
+++ b/config/install/responsive_image.styles.card_478x318.yml
@@ -71,3 +71,4 @@ image_style_mappings:
     image_mapping: card_2x_956x636
 breakpoint_group: stanford_image_styles
 fallback_image_style: card_2x_956x636
+

--- a/config/install/responsive_image.styles.cta_596x397.yml
+++ b/config/install/responsive_image.styles.cta_596x397.yml
@@ -73,3 +73,4 @@ image_style_mappings:
     image_mapping: cta_2x_1014x676
 breakpoint_group: stanford_image_styles
 fallback_image_style: cta_2x_1014x676
+

--- a/config/install/responsive_image.styles.responsive_1_1.yml
+++ b/config/install/responsive_image.styles.responsive_1_1.yml
@@ -1,0 +1,56 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - image.style.square_1192
+    - image.style.square_1900
+    - image.style.square_478
+    - image.style.square_956
+  module:
+    - stanford_image_styles
+id: responsive_1_1
+label: 'Responsive 1:1'
+image_style_mappings:
+  -
+    breakpoint_id: stanford_image_styles.lg
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: square_1192
+  -
+    breakpoint_id: stanford_image_styles.lg
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: square_1900
+  -
+    breakpoint_id: stanford_image_styles.md
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: square_956
+  -
+    breakpoint_id: stanford_image_styles.md
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: square_1900
+  -
+    breakpoint_id: stanford_image_styles.sm
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: square_956
+  -
+    breakpoint_id: stanford_image_styles.sm
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: square_1192
+  -
+    breakpoint_id: stanford_image_styles.xs
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: square_478
+  -
+    breakpoint_id: stanford_image_styles.xs
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: square_956
+breakpoint_group: stanford_image_styles
+fallback_image_style: square_1900
+

--- a/config/install/responsive_image.styles.stanford_hero_block_wide.yml
+++ b/config/install/responsive_image.styles.stanford_hero_block_wide.yml
@@ -14,8 +14,6 @@ dependencies:
     - image.style.breakpoint_xl_2x
   module:
     - stanford_image_styles
-_core:
-  default_config_hash: B0tXkjUZrA5gFY6X39MInsKCbjqw1oZHH9cYDwyQkhI
 id: stanford_hero_block_wide
 label: 'Stanford Hero Block - Wide'
 image_style_mappings:
@@ -81,3 +79,4 @@ image_style_mappings:
     image_mapping: breakpoint_sm_2x
 breakpoint_group: stanford_image_styles
 fallback_image_style: breakpoint_2xl_2x
+

--- a/tests/codeception/acceptance/StylesCest.php
+++ b/tests/codeception/acceptance/StylesCest.php
@@ -37,6 +37,10 @@ class StylesCest {
     $I->canSee('CTA - 1X - 596x397');
     $I->canSee('CTA - 2X - 1014x676');
     $I->canSee('CTA - 2X - 1192x794');
+    $I->canSee('Square - 478');
+    $I->canSee('Square - 956');
+    $I->canSee('Square - 1192');
+    $I->canSee('Square - 1900');
   }
 
   /**
@@ -47,6 +51,7 @@ class StylesCest {
     $I->canSee('Card - 478x318');
     $I->canSee('CTA - 596x397');
     $I->canSee('Stanford Hero Block - Wide');
+    $I->canSee('Responsive 1:1');
   }
 
 }


### PR DESCRIPTION
Additionally, added responsive 1:1 image style, fixed ymls for installation.

# READY FOR REVIEW

# Summary
- Adding the configs for 1:1 aspect ratio image styles and a responsive 1:1 image style.

# Needed By (Date)
- 7/24/2020

# Urgency
- not critical

# Steps to Test

1.  Same as for https://github.com/SU-SWS/stanford_profile/pull/260
2.  Make sure codeception tests come back green. 

# Affected Projects or Products
- https://github.com/SU-SWS/stanford_profile/pull/260

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/D8CORE-2155

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)